### PR TITLE
Fix color_mask construction for large num. colors 

### DIFF
--- a/cosmo-color.cpp
+++ b/cosmo-color.cpp
@@ -134,8 +134,9 @@ void find_bubbles(const debruijn_graph_shifted<> &dbg, sd_vector<> &colors, colo
                 branch_labels[branch_num] += base[x];
                 // build color mask
                 color_bv color_mask = 0;
-                for (int c = 0; c < num_colors; c++)
-                    color_mask |= colors[edge * num_colors + c] << c;
+                for (int c = 0; c < num_colors; c++) {
+		    color_mask.set(c, colors[edge*num_colors+c]);
+		}
                 branch_color[branch_num] = color_mask;
 
                 // walk along edges until we encounter 


### PR DESCRIPTION
When the number of colors is larger than a machine word, the current code to build color_mask can go awry. Here is why we think that's so:

color_mask is an appropriate-sized bitset, but colors[edge * num_colors + c] is an sd_vector, and sd_vector::operator returns a "value_type" which is, I think, an unsigned long or unsigned long long. So, if the shift is longer than the number of bits in "value_type" the result is wrong. This only shows up, of course, if the number of colors is reasonably large (e.g., greater than the number of bits in a machine word). However, this changed line should fix it.